### PR TITLE
Upgrade GitHub Actions Ubuntu Image to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-23.05.yml
+++ b/.github/workflows/build-23.05.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   OpenWrt_Builder:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
         fail-fast: false
@@ -144,7 +144,7 @@ jobs:
 
   Delete_Workflow:
     needs: [ OpenWrt_Builder ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@main

--- a/.github/workflows/build-24.10.yml
+++ b/.github/workflows/build-24.10.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   OpenWrt_Builder:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
         fail-fast: false
@@ -144,7 +144,7 @@ jobs:
 
   Delete_Workflow:
     needs: [ OpenWrt_Builder ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@main


### PR DESCRIPTION
- This PR aims to upgrade the Ubuntu image used by GitHub Actions to prepare for the upcoming brownout of Ubuntu 20.04, scheduled for February 1, 2025.

- As detailed in https://github.com/actions/runner-images/issues/11101, Ubuntu 20.04 will begin its brownout phase on February 1, 2025. To ensure the continued stability of GitHub Actions, it's necessary to upgrade the image in advance.